### PR TITLE
Solved Bug: Instant Auto refresh of Post on deletion

### DIFF
--- a/DevConnect/fronted/src/components/Post.jsx
+++ b/DevConnect/fronted/src/components/Post.jsx
@@ -9,7 +9,7 @@ import {DeleteIcon} from "@chakra-ui/icons"
 import { useRecoilValue } from 'recoil'
 import userAtom from '../atoms/userAtom'
 
-const Post = ({ post, postedBy }) => {
+const Post = ({ post, postedBy,setPosts }) => {
 
     const [liked, setLiked] = useState(false)
     const showToast = useShowToast();
@@ -58,7 +58,8 @@ const Post = ({ post, postedBy }) => {
                 return;
             }
             showToast("Success","Post Deleted Succesfully","success");
-
+           // For instant reload after deleting a post we will filter those post from set of all available post where there id is not equal to given post
+           setPosts((prev) => prev.filter((thosePost) => thosePost._id  !== post._id));
 
             
         } catch (error) {

--- a/DevConnect/fronted/src/pages/UserPage.jsx
+++ b/DevConnect/fronted/src/pages/UserPage.jsx
@@ -83,7 +83,7 @@ function UserPage() {
 
       {
         posts && posts.map((post) =>(
-          <Post key={post._id} post={post} postedBy={post.postedBy}/>
+          <Post key={post._id} post={post} postedBy={post.postedBy} setPosts={setPosts}/>
         ))
       }
       {/* <UserPost Likes={1200} Replies={481} postImg="/post1.png" postTitle="Let's talk about threads"/>


### PR DESCRIPTION
"Implement auto filtering of posts upon deletion

Added functionality to automatically filter posts upon deletion in the application. Upon confirming the deletion of a post, the system will sends a DELETE request to the server. If successful, the deleted post is removed from the UI in real-time without requiring a page reload. Additionally, a confirmation dialog is displayed to ensure the user intends to delete the post. Error handling is implemented to display error messages if the deletion process fails."
![image](https://github.com/Vikas-Yadav-79/DevConnect-Threads/assets/121033913/f907343e-ce35-4495-8b7a-660f2c5dadc4)

After DELETION :- No Need To reload

![image](https://github.com/Vikas-Yadav-79/DevConnect-Threads/assets/121033913/f78092f3-6b7d-4a9d-9d43-cbf70eeefda5)

